### PR TITLE
Add perform_skipped event type

### DIFF
--- a/lib/resque/plugins/clues/job_extension.rb
+++ b/lib/resque/plugins/clues/job_extension.rb
@@ -29,9 +29,10 @@ module Resque
             if Clues.configured? and payload['clues_metadata']
               Clues.event_publisher.publish(:perform_started, Clues.now, queue, payload['clues_metadata'], payload['class'], *payload['args'])
               @perform_started = Time.now
-              _base_perform.tap do 
+              _base_perform.tap do
                 payload['clues_metadata']['time_to_perform'] = Clues.time_delta_since(@perform_started)
-                Clues.event_publisher.publish(:perform_finished, Clues.now, queue, payload['clues_metadata'], payload['class'], *payload['args'])
+                event_type = Thread.current["perform_skipped"] ? :perform_skipped : :perform_finished
+                Clues.event_publisher.publish(event_type, Clues.now, queue, payload['clues_metadata'], payload['class'], *payload['args'])
               end
             else
               _base_perform

--- a/resque-clues.gemspec
+++ b/resque-clues.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake', '~> 0.9.2.2'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'pry'
-  gem.add_development_dependency 'pry-debugger'
   gem.add_development_dependency 'cane'
 end

--- a/spec/job_extension_spec.rb
+++ b/spec/job_extension_spec.rb
@@ -49,6 +49,12 @@ describe Resque::Plugins::Clues::JobExtension do
           metadata['time_to_perform'].nil?.should == false
         end
       end
+
+      it "should publish a perform_skipped event if perform doesn't happen" do
+        @job = Resque::Job.new(:test_queue, {"class" => SkippedTestWorker.to_s, "args" => [1,2], 'clues_metadata' => {}})
+        @job.perform
+        verify_event :perform_skipped, event_class: SkippedTestWorker.to_s
+      end
     end
 
     describe "#fail" do

--- a/spec/skipped_test_worker.rb
+++ b/spec/skipped_test_worker.rb
@@ -1,0 +1,9 @@
+class SkippedTestWorker
+  @queue = :test_queue
+
+  def self.perform(first, second)
+    # This would normally be set in an around_perform block when it fails to
+    # acquire a lock. Fake it here instead of adding a new plugin dependency
+    Thread.current["perform_skipped"] = true
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rspec'
 require 'pry'
 require 'resque-clues'
+require 'skipped_test_worker'
 require 'test_worker'
 require 'test_publisher'
 
@@ -19,13 +20,13 @@ def reset_redis
   Resque.redis.flushdb
 end
 
-def verify_event(event_type, opts={event_index: -1})
-  publisher.event_type(opts[:event_index]).should == event_type
-  publisher.timestamp(opts[:event_index]).should_not be_empty
-  publisher.queue(opts[:event_index]).should == :test_queue
-  publisher.klass(opts[:event_index]).should == 'TestWorker'
-  publisher.args(opts[:event_index]).should == [1, 2]
-  yield(publisher.metadata(opts[:event_index])) if block_given?
+def verify_event(event_type, event_index: -1, event_class: 'TestWorker')
+  publisher.event_type(event_index).should == event_type
+  publisher.timestamp(event_index).should_not be_empty
+  publisher.queue(event_index).should == :test_queue
+  publisher.klass(event_index).should == event_class
+  publisher.args(event_index).should == [1, 2]
+  yield(publisher.metadata(event_index)) if block_given?
 end
 
 def unpatch_resque


### PR DESCRIPTION
## Why?

We currently raise errors when the resque-lock-timeout plugin skips a job to avoid resque-clues logging it as performed, which is causing issues here https://auctane.atlassian.net/browse/SHIPIT-21737

Based on this comment, logging a perform_skipped event will allow us to stop raising the error
https://github.com/ShippingEasy/ship-it/blob/staging/lib/resque_fail_if_lock_prevents_perform.rb#L9

## What?

To avoid that behavior, and make the logs more accurate, a job skip will set `perform_skipped` on the current thread (outside this plugin). And if set, resque-clues will log a `perform_skipped` event.

Removed pry-debugger from the gemspec since it was breaking the bundle, 10 years old, and just a development dependency.